### PR TITLE
Add more shortcuts for vimium-like navigation

### DIFF
--- a/src/js/background/constants.js
+++ b/src/js/background/constants.js
@@ -59,7 +59,10 @@ define([
 			MoveTabLeft: "moveTabLeft",
 			MoveTabRight: "moveTabRight",
 			CopyURL: "copyURL",
-			CopyTitleURL: "copyTitleURL"
+			CopyTitleURL: "copyTitleURL",
+			SelectPreviousItem: "selectPreviousItem",
+			SelectNextItem: "selectNextItem",
+			EscapeBehavior: "escapeBehavior",
 		}
 	}));
 });

--- a/src/js/options/keyboard-shortcuts.js
+++ b/src/js/options/keyboard-shortcuts.js
@@ -107,7 +107,22 @@ define([
 				id: k.Shortcuts.CopyTitleURL,
 				label: <span>Copy the <b>title and URL</b> of the selected item</span>,
 				validate: validateSomeModifier
-			}
+			},
+			{
+				id: k.Shortcuts.SelectPreviousItem,
+				label: <span>Select the <b>previous</b> item.</span>,
+				validate: validateSomeModifier
+			},
+			{
+				id: k.Shortcuts.SelectNextItem,
+				label: <span>Select the <b>next</b> item.</span>,
+				validate: validateSomeModifier
+			},
+			{
+				id: k.Shortcuts.EscapeBehavior,
+				label: <span>Act as another <b>escape</b> key.</span>,
+				validate: validateSomeModifier
+			},
 		],
 		fixed: [
 			{

--- a/src/js/popup/shortcuts/popup-shortcuts.js
+++ b/src/js/popup/shortcuts/popup-shortcuts.js
@@ -42,7 +42,10 @@ define([
 		[k.Shortcuts.MoveTabLeft]: event => moveTab(-1, event.shiftKey),
 		[k.Shortcuts.MoveTabRight]: event => moveTab(1, event.shiftKey),
 		[k.Shortcuts.CopyURL]: () => self.copyItemURL(selectedTab(), false),
-		[k.Shortcuts.CopyTitleURL]: () => self.copyItemURL(selectedTab(), true)
+		[k.Shortcuts.CopyTitleURL]: () => self.copyItemURL(selectedTab(), true),
+		[k.Shortcuts.SelectPreviousItem]: () => self.modifySelected(-1),
+		[k.Shortcuts.SelectNextItem]: () => self.modifySelected(1),
+		[k.Shortcuts.EscapeBehavior]: event => self.clearQuery(event.target.value),
 	};
 	const ShiftShortcuts = {
 		[k.Shortcuts.MoveTabLeft]: 1,


### PR DESCRIPTION
> This adds the ability to set custom shortcuts for up/down in the picker,
so you can do ctrl-p and ctrl-n as you do with the omnibar and the
vomnibar in vimium. It also adds the ability to set custom shortcut
behavior, so ctrl-[ escapes as it does in vim.

Is this something you'd be interested in merging? For now I'm just playing around with in my private fork. I'd tried QuicKey in the past and gone back to vimium because I missed these shortcuts. Very easy to implement, though.

FWIW I'm not able to build it (at least not with `grunt`). There is an unrelated error that I also get on `master`.